### PR TITLE
Add NXT support for Linux

### DIFF
--- a/nxt/run-upload-programs.md
+++ b/nxt/run-upload-programs.md
@@ -42,6 +42,43 @@
 
 ![](../.gitbook/assets/nxt-usb-2.png)
 
+Если вы хотите использовать режим «Генерация» на Linux, то:
+
+1. Откройте терминал (его можно открыть комбинацией Ctrl+Alt+T) и напишите: 
+```
+sudo addgroup legonxt
+sudo adduser $USER legonxt
+```
+2. Создайте файл с именем 45-legonxt.rules
+3. Заполните его содержимым: 
+```
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0694", ATTRS{idProduct}=="0002", SYMLINK+="legonxt-%k", GROUP="legonxt", MODE="0666"
+
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="6124", SYMLINK+="legonxt-%k", GROUP="legonxt", MODE="0666"
+```
+
+4. Напишите из терминала (его можно открыть комбинацией Ctrl+Alt+T)
+    
+```sudo cp 45-legonxt.rules /etc/udev/rules.d```
+
+   После перезагрузки Ваше устройство будет распознавать контроллер.
+
+
+5. Вам понадобится arm-none-eabi. Его можно установить по [ссылке](https://developer.arm.com/-/media/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-aarch64-none-elf.tar.xz?rev=a8bbb76353aa44a69ce6b11fd560142d&hash=8DC6C55310058C1594FD6EEFD60F0B2528265C64). Затем необходимо разархивировать.
+
+Так же вы можете запустить установочный скрипт download-arm-none-eabi.sh через консоль, он находится в папке TRIKStudio/bin/nxt-tools
+
+Чтобы его запустить, достаточно написать в консоль из папки со скриптом
+```chmod +x download-arm-eabi.sh
+./download-arm-eabi.sh
+```
+Чтобы получить более подробную инструкцию по запуску скрипта, напишите
+```
+./download-arm-eabi.sh --help
+```
+
+6. Зайдите в Настройки. Укажите путь к папке, полученной после разархивации, а затем нажмите "Применить".
+
 ## **Загрузка на контроллер**
 
 Из TRIK Studio можно загрузить готовую программу на робота, чтобы в дальнейшем автономно её исполнять без связи с компьютером.


### PR DESCRIPTION
## What? 
I've added NXT support for GNU/Linux so [this PR](https://github.com/trikset/trik-studio/pull/1696) allows to compile and load programs via USB connection on Lego NXT. 
I suggest the user to follow the link https://help.trikset.com/nxt/run-upload-programs to get help.
## How?
I have updated run-upload-programs.md
